### PR TITLE
Fix TypeError by adding null check for searchParams.get('family')

### DIFF
--- a/content.js
+++ b/content.js
@@ -19,14 +19,19 @@ chrome.storage.sync.get(['selectedFontUrl', 'excludedUrls'], function (data) {
         link.rel = 'stylesheet';
         document.head.appendChild(link);
 
-        const fontName = new URL(data.selectedFontUrl).searchParams.get('family').split(':')[0].replace(/\+/g, ' ');
+        const fontFamily = new URL(data.selectedFontUrl).searchParams.get('family');
+        if (fontFamily) {
+            const fontName = fontFamily.split(':')[0].replace(/\+/g, ' ');
 
-        const style = document.createElement('style');
-        style.textContent = `
-            *:not([class*="icon"]) {
-                font-family: '${fontName}', sans-serif !important;
-            }
-        `;
-        document.head.appendChild(style);
+            const style = document.createElement('style');
+            style.textContent = `
+                *:not([class*="icon"]) {
+                    font-family: '${fontName}', sans-serif !important;
+                }
+            `;
+            document.head.appendChild(style);
+        } else {
+            console.error('Error: Font family parameter is missing in the URL');
+        }
     }
 });


### PR DESCRIPTION
Add null check for `searchParams.get('family')` to avoid `TypeError`.

- Log an error message if `searchParams.get('family')` returns null.
